### PR TITLE
Add Notice about newline escape issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Keeping the messages short is probably a good idea; use something such as the fo
 
 	{TRIGGER.NAME} - {HOSTNAME} ({IPADDRESS})
 
+IMPORTANT: Make sure there is no newline in the message body. As that will break the JSON currently.
 Additionally, you can have multiple different Zabbix users each with "Mattermost" media types that notify unique Mattermost users or channels upon different triggered Zabbix actions.
 
 


### PR DESCRIPTION
I had the problem that I wouldn't receive PROBLEM notifications, because I had a multiline comment.

Currently, the newlines are not escaped. In JSON a blank newline is not allowed and Zabbix will reject these.

When I post a multiline comment, this will happen:

```
# payload
Payload payload={"icon_url": "https://assets.zabbix.com/img/logo/zabbix_logo_500x131.png", "attachments": [ {"color": "#ff2a00", "text": "PROBLEM: Disk almost full - xxxxx.xxxxx.com (0.0.0.0)
                                                                                                                                                                                                                    "} ], "channel": "monitoring", "username": "zabbix", "icon_emoji": ""}

# curl response
{"id":"Unable to parse incoming data","message":"Unable to parse incoming data","detailed_error":"","request_id":"x36raewt3i8tjxae4r7kdt5b6y","status_code":400}

# Exit Code of Curl: 0
```

Until that newline can be escaped, at least the hint in the README will help other user to not run into the issue.